### PR TITLE
smbios: add EntryPoint interface and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See `cmd/lssmbios` for a runnable example.  Here's the gist of it:
 
 ```go
 // Find SMBIOS data in operating system-specific location.
-rc, err := smbios.Stream()
+rc, ep, err := smbios.Stream()
 if err != nil {
 	log.Fatalf("failed to open stream: %v", err)
 }
@@ -24,6 +24,10 @@ ss, err := d.Decode()
 if err != nil {
 	log.Fatalf("failed to decode structures: %v", err)
 }
+
+// Determine SMBIOS version from entry point.
+major, minor, rev := ep.Version()
+fmt.Printf("SMBIOS %d.%d.%d\n", major, minor, rev)
 
 for _, s := range ss {
 	fmt.Println(s)

--- a/cmd/lssmbios/main.go
+++ b/cmd/lssmbios/main.go
@@ -24,7 +24,7 @@ import (
 
 func main() {
 	// Find SMBIOS data in operating system-specific location.
-	rc, err := smbios.Stream()
+	rc, ep, err := smbios.Stream()
 	if err != nil {
 		log.Fatalf("failed to open stream: %v", err)
 	}
@@ -37,6 +37,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to decode structures: %v", err)
 	}
+
+	// Determine SMBIOS version from entry point.
+	major, minor, rev := ep.Version()
+	fmt.Printf("SMBIOS %d.%d.%d\n", major, minor, rev)
 
 	for _, s := range ss {
 		fmt.Println(s)

--- a/smbios/decoder.go
+++ b/smbios/decoder.go
@@ -41,15 +41,15 @@ type Decoder struct {
 	b  []byte
 }
 
-// Stream locates and opens a stream of SMBIOS data from an operating
-// system-specific location.  The stream must be closed after decoding
-// to free its resources.
+// Stream locates and opens a stream of SMBIOS data and the SMBIOS entry
+// point from an operating system-specific location.  The stream must be
+// closed after decoding to free its resources.
 //
 // If no suitable location is found, an error is returned.
-func Stream() (io.ReadCloser, error) {
-	rc, err := stream()
+func Stream() (io.ReadCloser, EntryPoint, error) {
+	rc, ep, err := stream()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// The io.ReadCloser from stream could be any one of a number of types
@@ -58,7 +58,7 @@ func Stream() (io.ReadCloser, error) {
 	// To prevent the caller from potentially tampering with something dangerous
 	// like mmap'd memory by using a type assertion, we make the io.ReadCloser
 	// into an opaque and unexported type to prevent type assertion.
-	return &opaqueReadCloser{rc: rc}, nil
+	return &opaqueReadCloser{rc: rc}, ep, nil
 }
 
 // NewDecoder creates a Decoder which decodes Structures from the input stream.

--- a/smbios/entrypoint.go
+++ b/smbios/entrypoint.go
@@ -1,0 +1,218 @@
+// Copyright 2017 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smbios
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+// Anchor strings used to detect entry points.
+var (
+	magic32  = []byte("_SM_")
+	magic64  = []byte("_SM3_")
+	magicDMI = []byte("_DMI_")
+)
+
+// An EntryPoint is an SMBIOS entry point.  EntryPoints contain various
+// properties about SMBIOS, including its major, minor, and revision version
+// numbers.
+//
+// Use a type assertion to access detailed EntryPoint information.
+type EntryPoint interface {
+	Version() (major, minor, revision int)
+}
+
+// ParseEntryPoint parses an EntryPoint from the input stream.
+func ParseEntryPoint(r io.Reader) (EntryPoint, error) {
+	// Prevent unbounded reads since this structure should be small.
+	b, err := ioutil.ReadAll(io.LimitReader(r, 64))
+	if err != nil {
+		return nil, err
+	}
+
+	if l := len(b); l < 4 {
+		return nil, fmt.Errorf("too few bytes for SMBIOS entry point magic: %d", l)
+	}
+
+	switch {
+	case bytes.HasPrefix(b, magic32):
+		return parse32(b)
+	case bytes.HasPrefix(b, magic64):
+		return parse64(b)
+	}
+
+	return nil, fmt.Errorf("unrecognized SMBIOS entry point magic: %v", b[0:4])
+}
+
+var _ EntryPoint = &EntryPoint32Bit{}
+
+// EntryPoint32Bit is the SMBIOS 32-bit Entry Point structure, used starting
+// in SMBIOS 2.1.
+type EntryPoint32Bit struct {
+	Anchor                string
+	Checksum              uint8
+	Length                uint8
+	Major                 uint8
+	Minor                 uint8
+	MaxStructureSize      uint16
+	EntryPointRevision    uint8
+	FormattedArea         [5]byte
+	IntermediateAnchor    string
+	IntermediateChecksum  uint8
+	StructureTableLength  uint16
+	StructureTableAddress uint32
+	NumberStructures      uint16
+	BCDRevision           uint8
+}
+
+// Version implements EntryPoint.
+func (h *EntryPoint32Bit) Version() (major, minor, revision int) {
+	return int(h.Major), int(h.Minor), 0
+}
+
+// parse32 parses an EntryPoint32Bit from b.
+func parse32(b []byte) (*EntryPoint32Bit, error) {
+	l := len(b)
+
+	// Correct minimum length as of SMBIOS 3.1.1.
+	const expLen = 31
+	if l < expLen {
+		return nil, fmt.Errorf("expected SMBIOS 32-bit entry point length of at least %d, but got: %d", expLen, l)
+	}
+
+	length := b[5]
+	if l != int(length) {
+		return nil, fmt.Errorf("expected SMBIOS 32-bit entry point length %d, but got: %d", length, l)
+	}
+
+	// Look for intermediate anchor with DMI magic.
+	iAnchor := b[16:21]
+	if !bytes.Equal(iAnchor, magicDMI) {
+		return nil, fmt.Errorf("incorrect DMI magic in SMBIOS 32-bit entry point: %v", iAnchor)
+	}
+
+	// Entry point checksum occurs at index 4, compute and verify it.
+	const epChkIndex = 4
+	epChk := b[epChkIndex]
+	if err := checksum(epChk, epChkIndex, b); err != nil {
+		return nil, err
+	}
+
+	// Since we already computed the checksum for the outer entry point,
+	// no real need to compute it for the intermediate entry point.
+
+	ep := &EntryPoint32Bit{
+		Anchor:                string(b[0:4]),
+		Checksum:              epChk,
+		Length:                length,
+		Major:                 b[6],
+		Minor:                 b[7],
+		MaxStructureSize:      binary.LittleEndian.Uint16(b[8:10]),
+		EntryPointRevision:    b[10],
+		IntermediateAnchor:    string(iAnchor),
+		IntermediateChecksum:  b[21],
+		StructureTableLength:  binary.LittleEndian.Uint16(b[22:24]),
+		StructureTableAddress: binary.LittleEndian.Uint32(b[24:28]),
+		NumberStructures:      binary.LittleEndian.Uint16(b[28:30]),
+		BCDRevision:           b[30],
+	}
+	copy(ep.FormattedArea[:], b[10:15])
+
+	return ep, nil
+}
+
+var _ EntryPoint = &EntryPoint64Bit{}
+
+// EntryPoint64Bit is the SMBIOS 64-bit Entry Point structure, used starting
+// in SMBIOS 3.0.
+type EntryPoint64Bit struct {
+	Anchor                string
+	Checksum              uint8
+	Length                uint8
+	Major                 uint8
+	Minor                 uint8
+	Revision              uint8
+	EntryPointRevision    uint8
+	Reserved              uint8
+	StructureTableMaxSize uint32
+	StructureTableAddress uint64
+}
+
+// Version implements EntryPoint.
+func (h *EntryPoint64Bit) Version() (major, minor, revision int) {
+	return int(h.Major), int(h.Minor), int(h.Revision)
+}
+
+// parse64 parses an EntryPoint64Bit from b.
+func parse64(b []byte) (*EntryPoint64Bit, error) {
+	l := len(b)
+
+	// Correct minimum length as of SMBIOS 3.1.1.
+	const expLen = 24
+	if l < expLen {
+		return nil, fmt.Errorf("expected SMBIOS 64-bit entry point length of at least %d, but got: %d", expLen, l)
+	}
+
+	length := b[6]
+	if l != int(length) {
+		return nil, fmt.Errorf("expected SMBIOS 64-bit entry point length %d, but got: %d", length, l)
+	}
+
+	// Checksum occurs at index 5, compute and verify it.
+	const chkIndex = 5
+	chk := b[chkIndex]
+	if err := checksum(chk, chkIndex, b); err != nil {
+		return nil, err
+	}
+
+	return &EntryPoint64Bit{
+		Anchor:                string(b[0:5]),
+		Checksum:              chk,
+		Length:                length,
+		Major:                 b[7],
+		Minor:                 b[8],
+		Revision:              b[9],
+		EntryPointRevision:    b[10],
+		Reserved:              b[11],
+		StructureTableMaxSize: binary.LittleEndian.Uint32(b[12:16]),
+		StructureTableAddress: binary.LittleEndian.Uint64(b[16:24]),
+	}, nil
+}
+
+// checksum computes the checksum of b using the starting value of start, and
+// skipping the checksum byte which occurs at index chkIndex.
+//
+// checksum assumes that b has already had its bounds checked.
+func checksum(start uint8, chkIndex int, b []byte) error {
+	chk := start
+	for i := range b {
+		// Checksum computation does not include index of checksum byte.
+		if i == chkIndex {
+			continue
+		}
+
+		chk += b[i]
+	}
+
+	if chk != 0 {
+		return fmt.Errorf("invalid entry point checksum %#02x from initial checksum %#02x", chk, start)
+	}
+
+	return nil
+}

--- a/smbios/entrypoint_test.go
+++ b/smbios/entrypoint_test.go
@@ -1,0 +1,296 @@
+// Copyright 2017 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smbios_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/digitalocean/go-smbios/smbios"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseEntryPoint(t *testing.T) {
+	tests := []struct {
+		name                   string
+		b                      []byte
+		ep                     smbios.EntryPoint
+		major, minor, revision int
+		ok                     bool
+	}{
+		{
+			name: "short magic",
+			b:    []byte{0x00},
+		},
+		{
+			name: "unknown magic",
+			b:    []byte{0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name: "32, short entry point",
+			b: []byte{
+				'_', 'S', 'M', '_',
+			},
+		},
+		{
+			name: "32, bad length",
+			b: []byte{
+				'_', 'S', 'M', '_',
+				0x00,
+				0xff, // 255 length
+				0x00,
+				0x00,
+				0x00, 0x00,
+				0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				'_', 'F', 'O', 'O', '_',
+				0x00,
+				0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00,
+				0x00,
+			},
+		},
+		{
+			name: "32, bad intermediate anchor",
+			b: []byte{
+				'_', 'S', 'M', '_',
+				0x00,
+				31,
+				0x00,
+				0x00,
+				0x00, 0x00,
+				0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				'_', 'F', 'O', 'O', '_',
+				0x00,
+				0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00,
+				0x00,
+			},
+		},
+		{
+			name: "32, bad checksum",
+			b: []byte{
+				'_', 'S', 'M', '_',
+				0x00, // 0 checksum
+				31,
+				0x00,
+				0x00,
+				0x00, 0x00,
+				0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				'_', 'D', 'M', 'I', '_',
+				0x00,
+				0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00,
+				0x00,
+			},
+		},
+		{
+			name: "32, OK",
+			b: []byte{
+				'_', 'S', 'M', '_',
+				0xa4,
+				0x1f,
+				0x2,
+				0x8,
+				0xd4,
+				0x1, 0x0,
+				0x0, 0x0, 0x0, 0x0, 0x0,
+				'_', 'D', 'M', 'I', '_',
+				0x95,
+				0x5f, 0xf,
+				0x0, 0x90, 0xf0, 0x7a,
+				0x43, 0x0,
+				0x28,
+			},
+			ep: &smbios.EntryPoint32Bit{
+				Anchor:                "_SM_",
+				Checksum:              0xa4,
+				Length:                0x1f,
+				Major:                 0x02,
+				Minor:                 0x08,
+				MaxStructureSize:      0x01d4,
+				IntermediateAnchor:    "_DMI_",
+				IntermediateChecksum:  0x95,
+				StructureTableLength:  0x0f5f,
+				StructureTableAddress: 0x7af09000,
+				NumberStructures:      0x43,
+				BCDRevision:           0x28,
+			},
+			major: 2, minor: 8, revision: 0,
+			ok: true,
+		},
+		{
+			name: "32, OK, trailing data",
+			b: []byte{
+				'_', 'S', 'M', '_',
+				0xa4,
+				0x20,
+				0x2,
+				0x8,
+				0xd4,
+				0x1, 0x0,
+				0x0, 0x0, 0x0, 0x0, 0x0,
+				'_', 'D', 'M', 'I', '_',
+				0x95,
+				0x5f, 0xf,
+				0x0, 0x90, 0xf0, 0x7a,
+				0x43, 0x0,
+				0x28,
+				0xff,
+			},
+			ep: &smbios.EntryPoint32Bit{
+				Anchor:                "_SM_",
+				Checksum:              0xa4,
+				Length:                0x20,
+				Major:                 0x02,
+				Minor:                 0x08,
+				MaxStructureSize:      0x01d4,
+				IntermediateAnchor:    "_DMI_",
+				IntermediateChecksum:  0x95,
+				StructureTableLength:  0x0f5f,
+				StructureTableAddress: 0x7af09000,
+				NumberStructures:      0x43,
+				BCDRevision:           0x28,
+			},
+			major: 2, minor: 8, revision: 0,
+			ok: true,
+		},
+		{
+			name: "64, short entry point",
+			b: []byte{
+				'_', 'S', 'M', '3', '_',
+			},
+		},
+		{
+			name: "64, bad length",
+			b: []byte{
+				'_', 'S', 'M', '3', '_',
+				0x00,
+				0xff, // 255 length
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "64, bad checksum",
+			b: []byte{
+				'_', 'S', 'M', '3', '_',
+				0x00, // 0 checksum
+				0x18,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00,
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "64, OK",
+			b: []byte{
+				'_', 'S', 'M', '3', '_',
+				0x86,
+				0x18,
+				0x3,
+				0x0,
+				0x0,
+				0x1,
+				0x0,
+				0x53, 0x9, 0x0, 0x0,
+				0xb0, 0xb3, 0xe, 0x0, 0x0, 0x0, 0x0, 0x0,
+			},
+			ep: &smbios.EntryPoint64Bit{
+				Anchor:                "_SM3_",
+				Checksum:              0x86,
+				Length:                0x18,
+				Major:                 0x03,
+				EntryPointRevision:    0x01,
+				StructureTableMaxSize: 0x0953,
+				StructureTableAddress: 0x0eb3b0,
+			},
+			major: 3, minor: 0, revision: 0,
+			ok: true,
+		},
+		{
+			name: "64, OK, trailing data",
+			b: []byte{
+				'_', 'S', 'M', '3', '_',
+				0x86,
+				0x19,
+				0x3,
+				0x0,
+				0x0,
+				0x1,
+				0x0,
+				0x53, 0x9, 0x0, 0x0,
+				0xb0, 0xb3, 0xe, 0x0, 0x0, 0x0, 0x0, 0x0,
+				0xff,
+			},
+			ep: &smbios.EntryPoint64Bit{
+				Anchor:                "_SM3_",
+				Checksum:              0x86,
+				Length:                0x19,
+				Major:                 0x03,
+				EntryPointRevision:    0x01,
+				StructureTableMaxSize: 0x0953,
+				StructureTableAddress: 0x0eb3b0,
+			},
+			major: 3, minor: 0, revision: 0,
+			ok: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep, err := smbios.ParseEntryPoint(bytes.NewReader(tt.b))
+
+			if tt.ok && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tt.ok && err == nil {
+				t.Fatalf("expected an error, but none occurred: %v", err)
+			}
+
+			if !tt.ok {
+				// Don't bother doing comparison if entry point is invalid.
+				t.Logf("OK error: %v", err)
+				return
+			}
+
+			if diff := cmp.Diff(tt.ep, ep); diff != "" {
+				t.Fatalf("unexpected entry point (-want +got):\n%s", diff)
+			}
+
+			major, minor, revision := ep.Version()
+			want := []int{tt.major, tt.minor, tt.revision}
+			got := []int{major, minor, revision}
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("unexpected SMBIOS version (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These provide detailed SMBIOS information and will enable the `/dev/mem` fallback on Linux, and probably support for other platforms too.