### PR TITLE
smbios: add EntryPoint.Table method, loosen parsing restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ if err != nil {
 	log.Fatalf("failed to decode structures: %v", err)
 }
 
-// Determine SMBIOS version from entry point.
+// Determine SMBIOS version and table location from entry point.
 major, minor, rev := ep.Version()
-fmt.Printf("SMBIOS %d.%d.%d\n", major, minor, rev)
+addr, size := ep.Table()
+
+fmt.Printf("SMBIOS %d.%d.%d - table: address: %#x, size: %d\n",
+	major, minor, rev, addr, size)
 
 for _, s := range ss {
 	fmt.Println(s)

--- a/cmd/lssmbios/main.go
+++ b/cmd/lssmbios/main.go
@@ -38,9 +38,12 @@ func main() {
 		log.Fatalf("failed to decode structures: %v", err)
 	}
 
-	// Determine SMBIOS version from entry point.
+	// Determine SMBIOS version and table location from entry point.
 	major, minor, rev := ep.Version()
-	fmt.Printf("SMBIOS %d.%d.%d\n", major, minor, rev)
+	addr, size := ep.Table()
+
+	fmt.Printf("SMBIOS %d.%d.%d - table: address: %#x, size: %d\n",
+		major, minor, rev, addr, size)
 
 	for _, s := range ss {
 		fmt.Println(s)

--- a/smbios/entrypoint_test.go
+++ b/smbios/entrypoint_test.go
@@ -28,6 +28,7 @@ func TestParseEntryPoint(t *testing.T) {
 		b                      []byte
 		ep                     smbios.EntryPoint
 		major, minor, revision int
+		addr, size             int
 		ok                     bool
 	}{
 		{
@@ -134,6 +135,7 @@ func TestParseEntryPoint(t *testing.T) {
 				BCDRevision:           0x28,
 			},
 			major: 2, minor: 8, revision: 0,
+			addr: 0x7af09000, size: 0x0f5f,
 			ok: true,
 		},
 		{
@@ -170,6 +172,7 @@ func TestParseEntryPoint(t *testing.T) {
 				BCDRevision:           0x28,
 			},
 			major: 2, minor: 8, revision: 0,
+			addr: 0x7af09000, size: 0x0f5f,
 			ok: true,
 		},
 		{
@@ -232,6 +235,7 @@ func TestParseEntryPoint(t *testing.T) {
 				StructureTableAddress: 0x0eb3b0,
 			},
 			major: 3, minor: 0, revision: 0,
+			addr: 0x0eb3b0, size: 0x0953,
 			ok: true,
 		},
 		{
@@ -259,6 +263,7 @@ func TestParseEntryPoint(t *testing.T) {
 				StructureTableAddress: 0x0eb3b0,
 			},
 			major: 3, minor: 0, revision: 0,
+			addr: 0x0eb3b0, size: 0x0953,
 			ok: true,
 		},
 	}
@@ -285,11 +290,19 @@ func TestParseEntryPoint(t *testing.T) {
 			}
 
 			major, minor, revision := ep.Version()
-			want := []int{tt.major, tt.minor, tt.revision}
-			got := []int{major, minor, revision}
+			wantVersion := []int{tt.major, tt.minor, tt.revision}
+			gotVersion := []int{major, minor, revision}
 
-			if diff := cmp.Diff(want, got); diff != "" {
+			if diff := cmp.Diff(wantVersion, gotVersion); diff != "" {
 				t.Fatalf("unexpected SMBIOS version (-want +got):\n%s", diff)
+			}
+
+			addr, size := ep.Table()
+			wantTable := []int{tt.addr, tt.size}
+			gotTable := []int{addr, size}
+
+			if diff := cmp.Diff(wantTable, gotTable); diff != "" {
+				t.Fatalf("unexpected SMBIOS table info (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Changes in preparation for parsing entry point in memory.

/r @allanliu @aybabtme 