### PR TITLE
smbios: support UNIX-like operating systems, README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,44 @@ go-smbios [![Build Status](https://travis-ci.org/digitalocean/go-smbios.svg?bran
 Package `smbios` provides detection and access to System Management BIOS (SMBIOS)
 and Desktop Management Interface (DMI) data and structures.  Apache 2.0 Licensed.
 
+Introduction
+------------
+
+[SMBIOS](https://en.wikipedia.org/wiki/System_Management_BIOS) is a standard
+mechanism for fetching BIOS and hardware information from within an operating
+system.  It shares some similarities with the older DMI standard, and the two are
+often confused.
+
+To install this package, run:
+
+```
+$ go get github.com/digitalocean/go-smbios/smbios
+```
+
+This package is based on the [SMBIOS 3.1.1 specification](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.1.1.pdf),
+but should work with SMBIOS 2.0 and above.
+
+In general, it's up to hardware manufacturers to properly populate SMBIOS data,
+and many structures may not be populated correctly or at all; especially on
+consumer hardware.
+
+The `smbios.Structure` types created by this package can be decoded using the
+structure information in the SMBIOS specification.  In the future, some common
+structures may be parsed and readily available by using this package.
+
+Supported operating systems and their SMBIOS retrieval mechanisms include:
+
+- DragonFlyBSD (/dev/mem)
+- FreeBSD (/dev/mem)
+- Linux (sysfs and /dev/mem)
+- NetBSD (/dev/mem)
+- OpenBSD (/dev/mem)
+- Solaris (/dev/mem)
+
+At this time, Windows and macOS are not supported, as they do not expose
+SMBIOS information in the same way as the supported operating systems. Pull
+requests are welcome to add support for these operating systems.
+
 Example
 -------
 

--- a/smbios/stream_linux.go
+++ b/smbios/stream_linux.go
@@ -17,17 +17,11 @@
 package smbios
 
 import (
-	"bytes"
-	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
 const (
-	// Linux system memory location used to find SMBIOS information.
-	devMem = "/dev/mem"
-
 	// sysfs locations for SMBIOS information.
 	sysfsDMI        = "/sys/firmware/dmi/tables/DMI"
 	sysfsEntryPoint = "/sys/firmware/dmi/tables/smbios_entry_point"
@@ -41,6 +35,7 @@ func stream() (io.ReadCloser, EntryPoint, error) {
 	case err == nil:
 		return sysfsStream(sysfsEntryPoint, sysfsDMI)
 	case os.IsNotExist(err):
+		// Fall back to the standard UNIX-like system method.
 		return devMemStream()
 	default:
 		return nil, nil, err
@@ -67,101 +62,4 @@ func sysfsStream(entryPoint, dmi string) (io.ReadCloser, EntryPoint, error) {
 	}
 
 	return sf, ep, nil
-}
-
-// devMemStream reads the SMBIOS entry point and structure stream from
-// the older but more common /dev/mem interface.
-func devMemStream() (io.ReadCloser, EntryPoint, error) {
-	mem, err := os.Open(devMem)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer mem.Close()
-
-	// SMBIOS specification indicates that the entry point should exist
-	// between these two memory addresses.
-	const (
-		startAddr = 0x000f0000
-		endAddr   = 0x000fffff
-	)
-
-	return memoryStream(mem, startAddr, endAddr)
-}
-
-// memoryStream reads the SMBIOS entry point and structure stream from
-// an io.ReadSeeker (usually system memory).
-//
-// memoryStream is an entry point for tests.
-//
-// TODO(mdlayher): determine if memoryStream is cross platform-compatible.
-func memoryStream(rs io.ReadSeeker, startAddr, endAddr int) (io.ReadCloser, EntryPoint, error) {
-	// Try to find the entry point.
-	addr, err := findEntryPoint(rs, startAddr, endAddr)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Found it; seek to the location of the entry point.
-	if _, err := rs.Seek(int64(addr), io.SeekStart); err != nil {
-		return nil, nil, err
-	}
-
-	// Read the entry point and determine where the SMBIOS table is.
-	ep, err := ParseEntryPoint(rs)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Seek to the start of the SMBIOS table.
-	tableAddr, tableSize := ep.Table()
-	if _, err := rs.Seek(int64(tableAddr), io.SeekStart); err != nil {
-		return nil, nil, err
-	}
-
-	// Make a copy of the memory so we don't return a handle to system memeory
-	// to the caller.
-	out := make([]byte, tableSize)
-	if _, err := io.ReadFull(rs, out); err != nil {
-		return nil, nil, err
-	}
-
-	return ioutil.NopCloser(bytes.NewReader(out)), ep, nil
-}
-
-// findEntryPoint attempts to locate the entry point structure in the io.ReadSeeker
-// using the start and end bound as hints for its location.
-func findEntryPoint(rs io.ReadSeeker, start, end int) (int, error) {
-	// Begin searching at the start bound.
-	if _, err := rs.Seek(int64(start), io.SeekStart); err != nil {
-		return 0, err
-	}
-
-	// Iterate one "paragraph" of memory at a time until we either find the entry point
-	// or reach the end bound.
-	const paragraph = 16
-	b := make([]byte, paragraph)
-
-	var (
-		addr  int
-		found bool
-	)
-
-	for addr = start; addr < end; addr += paragraph {
-		if _, err := io.ReadFull(rs, b); err != nil {
-			return 0, err
-		}
-
-		// Both the 32-bit and 64-bit entry point have a similar prefix.
-		if bytes.HasPrefix(b, magicPrefix) {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return 0, errors.New("no SMBIOS entry point found in memory")
-	}
-
-	// Return the exact memory location of the entry point.
-	return addr, nil
 }

--- a/smbios/stream_memory.go
+++ b/smbios/stream_memory.go
@@ -1,0 +1,125 @@
+// Copyright 2017 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smbios
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+const (
+	// devMem is the UNIX-like system memory device location used to
+	// find SMBIOS information.
+	devMem = "/dev/mem"
+
+	// SMBIOS specification indicates that the entry point should exist
+	// between these two memory addresses.
+	startAddr = 0x000f0000
+	endAddr   = 0x000fffff
+)
+
+// memoryStream reads the SMBIOS entry point and structure stream from
+// an io.ReadSeeker (usually system memory).
+//
+// memoryStream is an entry point for tests.
+func memoryStream(rs io.ReadSeeker, startAddr, endAddr int) (io.ReadCloser, EntryPoint, error) {
+	// Try to find the entry point.
+	addr, err := findEntryPoint(rs, startAddr, endAddr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Found it; seek to the location of the entry point.
+	if _, err := rs.Seek(int64(addr), io.SeekStart); err != nil {
+		return nil, nil, err
+	}
+
+	// Read the entry point and determine where the SMBIOS table is.
+	ep, err := ParseEntryPoint(rs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Seek to the start of the SMBIOS table.
+	tableAddr, tableSize := ep.Table()
+	if _, err := rs.Seek(int64(tableAddr), io.SeekStart); err != nil {
+		return nil, nil, err
+	}
+
+	// Make a copy of the memory so we don't return a handle to system memory
+	// to the caller.
+	out := make([]byte, tableSize)
+	if _, err := io.ReadFull(rs, out); err != nil {
+		return nil, nil, err
+	}
+
+	return ioutil.NopCloser(bytes.NewReader(out)), ep, nil
+}
+
+// findEntryPoint attempts to locate the entry point structure in the io.ReadSeeker
+// using the start and end bound as hints for its location.
+func findEntryPoint(rs io.ReadSeeker, start, end int) (int, error) {
+	// Begin searching at the start bound.
+	if _, err := rs.Seek(int64(start), io.SeekStart); err != nil {
+		return 0, err
+	}
+
+	// Iterate one "paragraph" of memory at a time until we either find the entry point
+	// or reach the end bound.
+	const paragraph = 16
+	b := make([]byte, paragraph)
+
+	var (
+		addr  int
+		found bool
+	)
+
+	for addr = start; addr < end; addr += paragraph {
+		if _, err := io.ReadFull(rs, b); err != nil {
+			return 0, err
+		}
+
+		// Both the 32-bit and 64-bit entry point have a similar prefix.
+		if bytes.HasPrefix(b, magicPrefix) {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return 0, errors.New("no SMBIOS entry point found in memory")
+	}
+
+	// Return the exact memory location of the entry point.
+	return addr, nil
+}
+
+// devMemStream reads the SMBIOS entry point and structure stream from
+// the UNIX-like system /dev/mem device.
+//
+// This is UNIX-like system specific, but since it doesn't employ any system
+// calls or OS-dependent constants, it remains in this file for simplicity.
+func devMemStream() (io.ReadCloser, EntryPoint, error) {
+	mem, err := os.Open(devMem)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer mem.Close()
+
+	return memoryStream(mem, startAddr, endAddr)
+}

--- a/smbios/stream_unix.go
+++ b/smbios/stream_unix.go
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build !dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+//+build dragonfly freebsd netbsd openbsd solaris
+
+// Linux intentionally omitted because it has an alternative method that
+// is used before attempting /dev/mem access.  See stream_linux.go.
 
 package smbios
 
 import (
-	"fmt"
 	"io"
-	"runtime"
 )
 
-// stream is not implemented for unsupported platforms.
+// stream opens the SMBIOS entry point and an SMBIOS structure stream.
 func stream() (io.ReadCloser, EntryPoint, error) {
-	return nil, nil, fmt.Errorf("opening SMBIOS stream not implemented on %q", runtime.GOOS)
+	// Use the standard UNIX-like system method.
+	return devMemStream()
 }


### PR DESCRIPTION
Adds support for all UNIX-like systems that expose `/dev/mem`, and also beefs up the README.