### PR TITLE
Add support for /dev/smbios on Solaris

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Matt Layher <mlayher@digitalocean.com>
 Contributors
 ------------
 Christopher Dudley <chris@terainsights.com>
+Lars Meyer <lars.meyer@enginsight.com>

--- a/smbios/stream_solaris.go
+++ b/smbios/stream_solaris.go
@@ -1,3 +1,17 @@
+// Copyright 2017-2021 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build solaris
 
 package smbios

--- a/smbios/stream_solaris.go
+++ b/smbios/stream_solaris.go
@@ -1,0 +1,24 @@
+// +build solaris
+
+package smbios
+
+import (
+	"io"
+	"os"
+)
+
+const devSMBIOS = "/dev/smbios"
+
+func stream() (io.ReadCloser, EntryPoint, error) {
+	epf, err := os.Open(devSMBIOS)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ep, err := ParseEntryPoint(epf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return epf, ep, nil
+}

--- a/smbios/stream_unix.go
+++ b/smbios/stream_unix.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build dragonfly freebsd netbsd openbsd solaris
+//+build dragonfly freebsd netbsd openbsd
 
 // Linux intentionally omitted because it has an alternative method that
 // is used before attempting /dev/mem access.  See stream_linux.go.

--- a/smbios/stream_unix.go
+++ b/smbios/stream_unix.go
@@ -17,6 +17,9 @@
 // Linux intentionally omitted because it has an alternative method that
 // is used before attempting /dev/mem access.  See stream_linux.go.
 
+// Solaris intentionally omitted because it provides /dev/smbios.
+// See stream_solaris.go
+
 package smbios
 
 import (


### PR DESCRIPTION
On both OpenIndiana (illumos kernel) and Oracle Solaris 11, the `/dev/mem` method fails with error `read /dev/mem: bad address`. However, both systems provide `/dev/smbios`, which works with the existing `ParseEntryPoint` function. This PR makes it possible to use `/dev/smbios` on Solaris.